### PR TITLE
chore: check network interface earlier

### DIFF
--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -706,7 +706,7 @@ func (m *MachineScope) GetVMImage(ctx context.Context) (*infrav1.Image, error) {
 // Note: this logic exists only for purposes of ensuring backwards compatibility for old clusters created without the `subnetName` field being
 // set, and should be removed in the future when this field is no longer optional.
 func (m *MachineScope) SetSubnetName() error {
-	if m.AzureMachine.Spec.SubnetName == "" {
+	if m.AzureMachine.Spec.SubnetName == "" && len(m.AzureMachine.Spec.NetworkInterfaces) == 0 {
 		subnetName := ""
 		subnets := m.Subnets()
 		var subnetCount int
@@ -716,7 +716,7 @@ func (m *MachineScope) SetSubnetName() error {
 				subnetName = subnet.Name
 			}
 		}
-		if (subnetCount == 0 || subnetCount > 1 || subnetName == "") && len(m.AzureMachine.Spec.NetworkInterfaces) == 0 {
+		if subnetCount == 0 || subnetCount > 1 || subnetName == "" {
 			return errors.New("a subnet name must be specified when no subnets are specified or more than 1 subnet of the same role exist")
 		}
 

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -629,12 +629,12 @@ func (m *MachinePoolScope) getDeploymentStrategy() machinepool.TypedDeleteSelect
 // Note: this logic exists only for purposes of ensuring backwards compatibility for old clusters created without the `subnetName` field being
 // set, and should be removed in the future when this field is no longer optional.
 func (m *MachinePoolScope) SetSubnetName() error {
-	if m.AzureMachinePool.Spec.Template.SubnetName == "" {
+	if m.AzureMachinePool.Spec.Template.SubnetName == "" && len(m.AzureMachinePool.Spec.Template.NetworkInterfaces) == 0 {
 		subnetName := ""
 		for _, subnet := range m.NodeSubnets() {
 			subnetName = subnet.Name
 		}
-		if (len(m.NodeSubnets()) == 0 || len(m.NodeSubnets()) > 1 || subnetName == "") && len(m.AzureMachinePool.Spec.Template.NetworkInterfaces) == 0 {
+		if len(m.NodeSubnets()) == 0 || len(m.NodeSubnets()) > 1 || subnetName == "" {
 			return errors.New("a subnet name must be specified when no subnets are specified or more than 1 subnet of role 'node' exist")
 		}
 


### PR DESCRIPTION

fixed: this function always wanted to set `spec.subnetName` to `nodes-3`, a.k.a the last subnet in the list form the azurecluster subnets

maybe move `SetSubnetName` in the defaulting webhook. as it sits now if `m.AzureMachine.Spec.SubnetName = subnetName` ever executes it will always fail because `spec.SubnetName` is immutable. otherwise remove the immutable check 