### PR TITLE
fix: format azure compute gallery image ID (#2747)

### DIFF
--- a/azure/converters/image.go
+++ b/azure/converters/image.go
@@ -50,8 +50,11 @@ func mpImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 }
 
 func computeImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
-	idTemplate := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s/versions/%s"
+	if image.ComputeGallery == nil && image.SharedGallery == nil {
+		return nil, errors.New("unable to convert compute image to SDK as SharedGallery or ComputeGallery fields are not set")
+	}
 
+	idTemplate := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s/versions/%s"
 	if image.SharedGallery != nil {
 		return &compute.ImageReference{
 			ID: to.StringPtr(fmt.Sprintf(idTemplate,
@@ -69,8 +72,8 @@ func computeImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 	if image.ComputeGallery.ResourceGroup != nil && image.ComputeGallery.SubscriptionID != nil {
 		return &compute.ImageReference{
 			ID: to.StringPtr(fmt.Sprintf(idTemplate,
-				image.ComputeGallery.SubscriptionID,
-				image.ComputeGallery.ResourceGroup,
+				to.String(image.ComputeGallery.SubscriptionID),
+				to.String(image.ComputeGallery.ResourceGroup),
 				image.ComputeGallery.Gallery,
 				image.ComputeGallery.Name,
 				image.ComputeGallery.Version,


### PR DESCRIPTION
* Add unit test to verify formatting of compute gallery image id

* fix: format azure compute gallery image ID

* add nil check for SharedGallery and ComputeGallery

* Fix error message text to use actual field names

Co-authored-by: Matt Boersma <Matt.Boersma@microsoft.com>

Co-authored-by: Matt Boersma <Matt.Boersma@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
