### PR TITLE
Rolling update fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,13 +479,17 @@ generate-addons: fetch-calico-manifests ## Generate metric-server, calico calico
 	$(KUSTOMIZE) build $(ADDONS_DIR)/calico-dual-stack > $(ADDONS_DIR)/calico-dual-stack.yaml
 
 # When updating this, make sure to also update the Windows image version in templates/addons/windows/calico.
-CALICO_VERSION := v3.25.0
+export CALICO_VERSION := v3.25.1
 # Where all downloaded Calico manifests are unpacked and stored.
 CALICO_RELEASES := $(ARTIFACTS)/calico
 # Path to manifests directory in a Calico release archive.
 CALICO_RELEASE_MANIFESTS_DIR := release-$(CALICO_VERSION)/manifests
 # Path where Calico manifests are stored which should be used for addons generation.
 CALICO_MANIFESTS_DIR := $(ARTIFACTS)/calico/$(CALICO_RELEASE_MANIFESTS_DIR)
+
+.PHONY: get-calico-version
+get-calico-version: ## Print the Calico version used for CNI in the repo.
+	@echo $(CALICO_VERSION)
 
 .PHONY: fetch-calico-manifests
 fetch-calico-manifests: $(CALICO_MANIFESTS_DIR) ## Get Calico release manifests and unzip them.

--- a/Tiltfile
+++ b/Tiltfile
@@ -373,7 +373,7 @@ def deploy_worker_templates(template, substitutions):
         calico_values = "./templates/addons/calico-dual-stack/values.yaml"
     else:
         calico_values = "./templates/addons/calico/values.yaml"
-    flavor_cmd += "; " + helm_cmd + " repo add projectcalico https://docs.tigera.io/calico/charts; " + helm_cmd + " --kubeconfig ./${CLUSTER_NAME}.kubeconfig install calico projectcalico/tigera-operator -f " + calico_values + " --namespace tigera-operator --create-namespace"
+    flavor_cmd += "; " + helm_cmd + " repo add projectcalico https://docs.tigera.io/calico/charts; " + helm_cmd + " --kubeconfig ./${CLUSTER_NAME}.kubeconfig install --version ${CALICO_VERSION} calico projectcalico/tigera-operator -f " + calico_values + " --namespace tigera-operator --create-namespace"
     if "intree-cloud-provider" not in flavor_name:
         flavor_cmd += "; " + helm_cmd + " --kubeconfig ./${CLUSTER_NAME}.kubeconfig install --repo https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo cloud-provider-azure --generate-name --set infra.clusterName=${CLUSTER_NAME}"
         if "flatcar" in flavor_name:  # append caCetDir location to the cloud-provider-azure helm install command for flatcar flavor

--- a/Tiltfile
+++ b/Tiltfile
@@ -376,6 +376,9 @@ def deploy_worker_templates(template, substitutions):
     flavor_cmd += "; " + helm_cmd + " repo add projectcalico https://docs.tigera.io/calico/charts; " + helm_cmd + " --kubeconfig ./${CLUSTER_NAME}.kubeconfig install calico projectcalico/tigera-operator -f " + calico_values + " --namespace tigera-operator --create-namespace"
     if "intree-cloud-provider" not in flavor_name:
         flavor_cmd += "; " + helm_cmd + " --kubeconfig ./${CLUSTER_NAME}.kubeconfig install --repo https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo cloud-provider-azure --generate-name --set infra.clusterName=${CLUSTER_NAME}"
+        if "flatcar" in flavor_name:  # append caCetDir location to the cloud-provider-azure helm install command for flatcar flavor
+            flavor_cmd += " --set-string cloudControllerManager.caCertDir=/usr/share/ca-certificates"
+
     local_resource(
         name = flavor_name,
         cmd = flavor_cmd,

--- a/api/v1beta1/types_class.go
+++ b/api/v1beta1/types_class.go
@@ -50,7 +50,7 @@ type AzureClusterClassSpec struct {
 	// CloudProviderConfigOverrides is an optional set of configuration values that can be overridden in azure cloud provider config.
 	// This is only a subset of options that are available in azure cloud provider config.
 	// Some values for the cloud provider config are inferred from other parts of cluster api provider azure spec, and may not be available for overrides.
-	// See: https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs
+	// See: https://cloud-provider-azure.sigs.k8s.io/install/configs
 	// Note: All cloud provider config values can be customized by creating the secret beforehand. CloudProviderConfigOverrides is only used when the secret is managed by the Azure Provider.
 	// +optional
 	CloudProviderConfigOverrides *CloudProviderConfigOverrides `json:"cloudProviderConfigOverrides,omitempty"`

--- a/azure/types.go
+++ b/azure/types.go
@@ -130,6 +130,15 @@ func (vmss VMSS) HasModelChanges(other VMSS) bool {
 	return !equal
 }
 
+// HasRollingUpdateChanges returns true if the spec fields which will mutate the Azure VMSS model are different.
+func (vmss VMSS) HasRollingUpdateChanges(other VMSS) bool {
+	equal := cmp.Equal(vmss.Image, other.Image) &&
+		cmp.Equal(vmss.Identity, other.Identity) &&
+		cmp.Equal(vmss.Zones, other.Zones) &&
+		cmp.Equal(vmss.Sku, other.Sku)
+	return !equal
+}
+
 // InstancesByProviderID returns VMSSVMs by ID.
 func (vmss VMSS) InstancesByProviderID(mode infrav1.OrchestrationModeType) map[string]VMSSVM {
 	instancesByProviderID := make(map[string]VMSSVM, len(vmss.Instances))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -431,7 +431,7 @@ spec:
                   is only a subset of options that are available in azure cloud provider
                   config. Some values for the cloud provider config are inferred from
                   other parts of cluster api provider azure spec, and may not be available
-                  for overrides. See: https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs
+                  for overrides. See: https://cloud-provider-azure.sigs.k8s.io/install/configs
                   Note: All cloud provider config values can be customized by creating
                   the secret beforehand. CloudProviderConfigOverrides is only used
                   when the secret is managed by the Azure Provider.'

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
@@ -318,7 +318,7 @@ spec:
                           that are available in azure cloud provider config. Some
                           values for the cloud provider config are inferred from other
                           parts of cluster api provider azure spec, and may not be
-                          available for overrides. See: https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs
+                          available for overrides. See: https://cloud-provider-azure.sigs.k8s.io/install/configs
                           Note: All cloud provider config values can be customized
                           by creating the secret beforehand. CloudProviderConfigOverrides
                           is only used when the secret is managed by the Azure Provider.'

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -404,7 +404,7 @@ func toCloudProviderRateLimitConfig(source infrav1.RateLimitConfig) *RateLimitCo
 }
 
 // CloudProviderRateLimitConfig represents the rate limiting configurations in azure cloud provider config.
-// See: https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs/#per-client-rate-limiting.
+// See: https://cloud-provider-azure.sigs.k8s.io/install/configs/#per-client-rate-limiting.
 // This is a copy of the struct used in cloud-provider-azure: https://github.com/kubernetes-sigs/cloud-provider-azure/blob/d585c2031925b39c925624302f22f8856e29e352/pkg/provider/azure_ratelimit.go#L25
 type CloudProviderRateLimitConfig struct {
 	RateLimitConfig

--- a/docs/book/src/topics/addons.md
+++ b/docs/book/src/topics/addons.md
@@ -168,6 +168,13 @@ Then install the Helm chart on the workload cluster:
 helm install --repo https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo cloud-provider-azure --generate-name --set infra.clusterName=${CLUSTER_NAME} --set "cloudControllerManager.clusterCIDR=${CCM_CIDR_BLOCK}"
 ```
 
+- **Note**: 
+  When working with **Flatcar machines**, append `--set-string cloudControllerManager.caCertDir=/usr/share/ca-certificates` to the `cloud-provider-azure` _helm_ command. The helm command to install cloud provider azure for Flatcar-flavored workload cluster will be:
+
+    ```bash
+    helm install --repo https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo cloud-provider-azure --generate-name --set infra.clusterName=${CLUSTER_NAME} --set "cloudControllerManager.clusterCIDR=${CCM_CIDR_BLOCK}" --set-string "cloudControllerManager.caCertDir=/usr/share/ca-certificates"
+    ```
+
 The Helm chart will pick the right version of `cloud-controller-manager` and `cloud-node-manager` to work with the version of Kubernetes your cluster is running.
 
 After running `helm install`, you should eventually see a set of pods like these in a `Running` state:

--- a/docs/book/src/topics/addons.md
+++ b/docs/book/src/topics/addons.md
@@ -29,7 +29,7 @@ Then install the Helm chart on the workload cluster:
 
 ```bash
 helm repo add projectcalico https://docs.tigera.io/calico/charts && \
-helm install calico projectcalico/tigera-operator -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico/values.yaml --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV4_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
+helm install calico projectcalico/tigera-operator --version v3.25.1 -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico/values.yaml --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV4_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
 ```
 
 ### For IPv6 Clusters
@@ -44,7 +44,7 @@ Then install the Helm chart on the workload cluster:
 
 ```bash
 helm repo add projectcalico https://docs.tigera.io/calico/charts && \
-helm install calico projectcalico/tigera-operator -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico-ipv6/values.yaml  --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV6_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
+helm install calico projectcalico/tigera-operator --version v3.25.1 -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico-ipv6/values.yaml  --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV6_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
 ```
 
 ### For Dual-Stack Clusters
@@ -60,7 +60,7 @@ Then install the Helm chart on the workload cluster:
 
 ```bash
 helm repo add projectcalico https://docs.tigera.io/calico/charts && \
-helm install calico projectcalico/tigera-operator -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico-dual-stack/values.yaml --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV4_CIDR_BLOCK}","installation.calicoNetwork.ipPools[1].cidr=${IPV6_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
+helm install calico projectcalico/tigera-operator --version v3.25.1 -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico-dual-stack/values.yaml --set-string "installation.calicoNetwork.ipPools[0].cidr=${IPV4_CIDR_BLOCK}","installation.calicoNetwork.ipPools[1].cidr=${IPV6_CIDR_BLOCK}" --namespace tigera-operator --create-namespace
 ```
 
 <aside class="note">

--- a/docs/book/src/topics/cloud-provider-config.md
+++ b/docs/book/src/topics/cloud-provider-config.md
@@ -54,7 +54,7 @@ spec:
 <h1> Warning </h1>
 
 Presently, only rate limit configuration is supported for overrides, and this works only on clusters running Kubernetes versions above `v1.18.0`.
-See [per client rate limiting](https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs/#per-client-rate-limiting) for more info.
+See [per client rate limiting](https://cloud-provider-azure.sigs.k8s.io/install/configs/#per-client-rate-limiting) for more info.
 
 </aside>
 

--- a/docs/book/src/topics/flatcar.md
+++ b/docs/book/src/topics/flatcar.md
@@ -39,3 +39,6 @@ If you would like customize your images please refer to the documentation on bui
 ## Trying it out
 
 To create a cluster using Flatcar Container Linux, use `flatcar` cluster flavor.
+
+- Note: When working with **Flatcar machines**, append `--set-string cloudControllerManager.caCertDir=/usr/share/ca-certificates` to the `cloud-provider-azure` _helm_ command. Refer ["External Cloud Provider's Note for flatcar-flavored machine"](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/764aa1e8bd02d150dff90ff6bc7f8daa2b38810f/docs/book/src/topics/addons.md#external-cloud-provider)
+  - However, no changes are needed when using tilt to bring up flatcar-flavored workload clusters.

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,9 @@
     command = "./docs/book/install-and-build.sh"
     publish = "docs/book/book"
 
+[build.environment]
+    GO_VERSION = "1.20"
+
 # Standard Netlify redirects
 [[redirects]]
     from = "https://master--kubernetes-sigs-cluster-api-provider-azure.netlify.com/*"

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -71,7 +71,9 @@ export AZURE_LOCATION_GPU="${AZURE_LOCATION_GPU:-$(capz::util::get_random_region
 export AZURE_LOCATION_EDGEZONE="${AZURE_LOCATION_EDGEZONE:-$(capz::util::get_random_region_edgezone)}"
 export AZURE_CONTROL_PLANE_MACHINE_TYPE="${AZURE_CONTROL_PLANE_MACHINE_TYPE:-"Standard_B2s"}"
 export AZURE_NODE_MACHINE_TYPE="${AZURE_NODE_MACHINE_TYPE:-"Standard_B2s"}"
-export KIND_EXPERIMENTAL_DOCKER_NETWORK="bridge"
+CALICO_VERSION=$(make get-calico-version)
+export CALICO_VERSION
+
 
 capz::util::generate_ssh_key
 

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -178,7 +178,8 @@ install_calico() {
         "${KUBECTL}" get configmap kubeadm-config --namespace=kube-system -o yaml | sed 's/namespace: kube-system/namespace: calico-system/' | "${KUBECTL}" apply -f - || return 1
     fi
     # install Calico CNI
-    echo "Installing Calico CNI via helm"
+    CALICO_VERSION=$(make get-calico-version)
+    echo "Installing Calico CNI ${CALICO_VERSION} via helm"
     if [[ "${CIDR0:-}" =~ .*:.* ]]; then
         echo "Cluster CIDR is IPv6"
         CALICO_VALUES_FILE="${REPO_ROOT}/templates/addons/calico-ipv6/values.yaml"
@@ -192,7 +193,7 @@ install_calico() {
         CALICO_VALUES_FILE="${REPO_ROOT}/templates/addons/calico/values.yaml"
         CIDR_STRING_VALUES="installation.calicoNetwork.ipPools[0].cidr=${CIDR0}"
     fi
-    "${HELM}" upgrade calico --install --repo https://docs.tigera.io/calico/charts tigera-operator -f "${CALICO_VALUES_FILE}" --set-string "${CIDR_STRING_VALUES}" --namespace calico-system || return 1
+    "${HELM}" upgrade calico --install --repo https://docs.tigera.io/calico/charts --version "${CALICO_VERSION}" tigera-operator -f "${CALICO_VALUES_FILE}" --set-string "${CIDR_STRING_VALUES}" --namespace calico-system || return 1
 }
 
 # install_cloud_provider_azure installs OOT cloud-provider-azure componentry onto the Cluster.

--- a/templates/addons/calico-dual-stack.yaml
+++ b/templates/addons/calico-dual-stack.yaml
@@ -4351,7 +4351,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.25.0
+        image: docker.io/calico/kube-controllers:v3.25.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -4428,7 +4428,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/typha:v3.25.0
+        image: docker.io/calico/typha:v3.25.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -4546,7 +4546,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.25.0
+        image: docker.io/calico/node:v3.25.1
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4621,7 +4621,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.25.0
+        image: docker.io/calico/cni:v3.25.1
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -4635,7 +4635,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.25.0
+        image: docker.io/calico/node:v3.25.1
         imagePullPolicy: IfNotPresent
         name: mount-bpffs
         securityContext:

--- a/templates/addons/calico-ipv6.yaml
+++ b/templates/addons/calico-ipv6.yaml
@@ -4340,7 +4340,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.25.0
+        image: docker.io/calico/kube-controllers:v3.25.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -4417,7 +4417,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/typha:v3.25.0
+        image: docker.io/calico/typha:v3.25.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -4535,7 +4535,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.25.0
+        image: docker.io/calico/node:v3.25.1
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4610,7 +4610,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.25.0
+        image: docker.io/calico/cni:v3.25.1
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -4624,7 +4624,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.25.0
+        image: docker.io/calico/node:v3.25.1
         imagePullPolicy: IfNotPresent
         name: mount-bpffs
         securityContext:

--- a/templates/addons/calico-ipv6/calico-policy-only.yaml
+++ b/templates/addons/calico-ipv6/calico-policy-only.yaml
@@ -4441,7 +4441,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.25.0
+          image: docker.io/calico/cni:v3.25.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4478,7 +4478,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.25.0
+          image: docker.io/calico/node:v3.25.1
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4504,7 +4504,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.25.0
+          image: docker.io/calico/node:v3.25.1
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4692,7 +4692,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.25.0
+          image: docker.io/calico/kube-controllers:v3.25.1
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.
@@ -4776,7 +4776,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: docker.io/calico/typha:v3.25.0
+      - image: docker.io/calico/typha:v3.25.1
         imagePullPolicy: IfNotPresent
         name: calico-typha
         ports:

--- a/templates/addons/calico.yaml
+++ b/templates/addons/calico.yaml
@@ -4355,7 +4355,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.25.0
+        image: docker.io/calico/kube-controllers:v3.25.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -4468,7 +4468,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.25.0
+        image: docker.io/calico/node:v3.25.1
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4540,7 +4540,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.25.0
+        image: docker.io/calico/cni:v3.25.1
         imagePullPolicy: IfNotPresent
         name: upgrade-ipam
         securityContext:
@@ -4575,7 +4575,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.25.0
+        image: docker.io/calico/cni:v3.25.1
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -4589,7 +4589,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.25.0
+        image: docker.io/calico/node:v3.25.1
         imagePullPolicy: IfNotPresent
         name: mount-bpffs
         securityContext:

--- a/templates/addons/calico/calico-vxlan.yaml
+++ b/templates/addons/calico/calico-vxlan.yaml
@@ -4440,7 +4440,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.25.0
+          image: docker.io/calico/cni:v3.25.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4468,7 +4468,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.25.0
+          image: docker.io/calico/cni:v3.25.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4511,7 +4511,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.25.0
+          image: docker.io/calico/node:v3.25.1
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4537,7 +4537,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.25.0
+          image: docker.io/calico/node:v3.25.1
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4752,7 +4752,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.25.0
+          image: docker.io/calico/kube-controllers:v3.25.1
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/templates/addons/windows/calico/calico.yaml
+++ b/templates/addons/windows/calico/calico.yaml
@@ -163,7 +163,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: sigwindowstools/calico-install:v3.25.0-hostprocess
+          image: sigwindowstools/calico-install:v3.25.1-hostprocess
           args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1"]
           imagePullPolicy: Always
           env:
@@ -205,7 +205,7 @@ spec:
               runAsUserName: "NT AUTHORITY\\system"
       containers:
       - name: calico-node-startup
-        image: sigwindowstools/calico-node:v3.25.0-hostprocess
+        image: sigwindowstools/calico-node:v3.25.1-hostprocess
         args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1"]
         workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/"
         imagePullPolicy: Always
@@ -232,7 +232,7 @@ spec:
         - name: VXLAN_VNI
           value: "4096"
       - name: calico-node-felix
-        image: sigwindowstools/calico-node:v3.25.0-hostprocess
+        image: sigwindowstools/calico-node:v3.25.1-hostprocess
         args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1"]
         imagePullPolicy: Always
         workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/"

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -710,7 +710,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -729,7 +729,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -740,7 +740,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-intree-cloud-provider-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-intree-cloud-provider-machine-pool.yaml
@@ -472,7 +472,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -491,7 +491,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -502,7 +502,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-intree-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-intree-cloud-provider.yaml
@@ -536,7 +536,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -555,7 +555,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -566,7 +566,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -644,7 +644,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -663,7 +663,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -674,7 +674,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
@@ -462,7 +462,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -481,7 +481,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -492,7 +492,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -456,7 +456,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -475,7 +475,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -486,7 +486,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -4643,7 +4643,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.25.0
+            image: docker.io/calico/kube-controllers:v3.25.1
             imagePullPolicy: IfNotPresent
             livenessProbe:
               exec:
@@ -4756,7 +4756,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.25.0
+            image: docker.io/calico/node:v3.25.1
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -4828,7 +4828,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.25.0
+            image: docker.io/calico/cni:v3.25.1
             imagePullPolicy: IfNotPresent
             name: upgrade-ipam
             securityContext:
@@ -4863,7 +4863,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.25.0
+            image: docker.io/calico/cni:v3.25.1
             imagePullPolicy: IfNotPresent
             name: install-cni
             securityContext:
@@ -4877,7 +4877,7 @@ data:
             - calico-node
             - -init
             - -best-effort
-            image: docker.io/calico/node:v3.25.0
+            image: docker.io/calico/node:v3.25.1
             imagePullPolicy: IfNotPresent
             name: mount-bpffs
             securityContext:

--- a/templates/test/ci/cluster-template-prow-topology.yaml
+++ b/templates/test/ci/cluster-template-prow-topology.yaml
@@ -187,7 +187,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -206,7 +206,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -217,7 +217,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -520,7 +520,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -539,7 +539,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -550,7 +550,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -592,7 +592,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -611,7 +611,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -622,7 +622,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -657,7 +657,7 @@ data:
     for rescheduling.\n      - key: CriticalAddonsOnly\n        operator: Exists\n
     \     - effect: NoExecute\n        operator: Exists\n      initContainers:\n        #
     This container installs the CNI binaries\n        # and CNI network config file
-    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.0-hostprocess\n
+    on each node.\n        - name: install-cni\n          image: sigwindowstools/calico-install:v3.25.1-hostprocess\n
     \         args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1\"]\n
     \         imagePullPolicy: Always\n          env:\n            # Name of the CNI
     config file to create.\n            - name: CNI_CONF_NAME\n              value:
@@ -676,7 +676,7 @@ data:
     cni-net-dir\n            - name: kubeadm-config\n              mountPath: /etc/kubeadm-config/\n
     \         securityContext:\n            windowsOptions:\n              hostProcess:
     true\n              runAsUserName: \"NT AUTHORITY\\\\system\"\n      containers:\n
-    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.0-hostprocess\n
+    \     - name: calico-node-startup\n        image: sigwindowstools/calico-node:v3.25.1-hostprocess\n
     \       args: [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1\"]\n
     \       workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        imagePullPolicy:
     Always\n        volumeMounts:\n        - name: calico-config-windows\n          mountPath:
@@ -687,7 +687,7 @@ data:
     name: CNI_IPAM_TYPE\n          value: \"calico-ipam\"\n        - name: CALICO_NETWORKING_BACKEND\n
     \         value: \"vxlan\"\n        - name: KUBECONFIG\n          value: \"C:/etc/cni/net.d/calico-kubeconfig\"\n
     \       - name: VXLAN_VNI\n          value: \"4096\"\n      - name: calico-node-felix\n
-    \       image: sigwindowstools/calico-node:v3.25.0-hostprocess\n        args:
+    \       image: sigwindowstools/calico-node:v3.25.1-hostprocess\n        args:
     [\"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/felix-service.ps1\"]\n        imagePullPolicy:
     Always\n        workingDir: \"$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/\"\n        volumeMounts:\n
     \       - name: calico-config-windows\n          mountPath: /etc/kube-calico-windows/\n

--- a/test/e2e/cloud-provider-azure.go
+++ b/test/e2e/cloud-provider-azure.go
@@ -66,7 +66,7 @@ func InstallCalicoAndCloudProviderAzureHelmChart(ctx context.Context, input clus
 	}
 
 	clusterProxy := input.ClusterProxy.GetWorkloadCluster(ctx, input.ConfigCluster.Namespace, input.ConfigCluster.ClusterName)
-	InstallHelmChart(ctx, clusterProxy, defaultNamespace, cloudProviderAzureHelmRepoURL, cloudProviderAzureChartName, cloudProviderAzureHelmReleaseName, options)
+	InstallHelmChart(ctx, clusterProxy, defaultNamespace, cloudProviderAzureHelmRepoURL, cloudProviderAzureChartName, cloudProviderAzureHelmReleaseName, options, "")
 
 	// Install Calico CNI Helm Chart. We do this before waiting for the pods to be ready because there is a co-dependency between CNI (nodes ready) and cloud-provider being initialized.
 	InstallCalicoHelmChart(ctx, input, cidrBlocks, hasWindows)
@@ -90,7 +90,7 @@ func InstallAzureDiskCSIDriverHelmChart(ctx context.Context, input clusterctl.Ap
 		options.Values = append(options.Values, "windows.useHostProcessContainers=true")
 	}
 	clusterProxy := input.ClusterProxy.GetWorkloadCluster(ctx, input.ConfigCluster.Namespace, input.ConfigCluster.ClusterName)
-	InstallHelmChart(ctx, clusterProxy, kubesystem, azureDiskCSIDriverHelmRepoURL, azureDiskCSIDriverChartName, azureDiskCSIDriverHelmReleaseName, options)
+	InstallHelmChart(ctx, clusterProxy, kubesystem, azureDiskCSIDriverHelmRepoURL, azureDiskCSIDriverChartName, azureDiskCSIDriverHelmReleaseName, options, "")
 	By("Waiting for Ready csi-azuredisk-controller deployment pods")
 	for _, d := range []string{"csi-azuredisk-controller"} {
 		waitInput := GetWaitForDeploymentsAvailableInput(ctx, clusterProxy, d, kubesystem, specName)

--- a/test/e2e/cloud-provider-azure.go
+++ b/test/e2e/cloud-provider-azure.go
@@ -61,6 +61,10 @@ func InstallCalicoAndCloudProviderAzureHelmChart(ctx context.Context, input clus
 		options.StringValues = append(options.StringValues, fmt.Sprintf("cloudNodeManager.imageTag=%s", os.Getenv("IMAGE_TAG_CNM")))
 	}
 
+	if input.ConfigCluster.Flavor == "flatcar" {
+		options.StringValues = append(options.StringValues, "cloudControllerManager.caCertDir=/usr/share/ca-certificates")
+	}
+
 	clusterProxy := input.ClusterProxy.GetWorkloadCluster(ctx, input.ConfigCluster.Namespace, input.ConfigCluster.ClusterName)
 	InstallHelmChart(ctx, clusterProxy, defaultNamespace, cloudProviderAzureHelmRepoURL, cloudProviderAzureChartName, cloudProviderAzureHelmReleaseName, options)
 

--- a/test/e2e/cni.go
+++ b/test/e2e/cni.go
@@ -22,6 +22,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -49,7 +50,7 @@ func InstallCalicoHelmChart(ctx context.Context, input clusterctl.ApplyClusterTe
 	By("Installing Calico CNI via helm")
 	values := getCalicoValues(cidrBlocks)
 	clusterProxy := input.ClusterProxy.GetWorkloadCluster(ctx, input.ConfigCluster.Namespace, input.ConfigCluster.ClusterName)
-	InstallHelmChart(ctx, clusterProxy, calicoOperatorNamespace, calicoHelmChartRepoURL, calicoHelmChartName, calicoHelmReleaseName, values)
+	InstallHelmChart(ctx, clusterProxy, calicoOperatorNamespace, calicoHelmChartRepoURL, calicoHelmChartName, calicoHelmReleaseName, values, os.Getenv(CalicoVersion))
 	workloadClusterClient := clusterProxy.GetClient()
 
 	// Copy the kubeadm configmap to the calico-system namespace. This is a workaround needed for the calico-node-windows daemonset to be able to run in the calico-system namespace.

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -84,6 +84,7 @@ const (
 	FlatcarVersion                  = "FLATCAR_VERSION"
 	SecurityScanFailThreshold       = "SECURITY_SCAN_FAIL_THRESHOLD"
 	SecurityScanContainer           = "SECURITY_SCAN_CONTAINER"
+	CalicoVersion                   = "CALICO_VERSION"
 	ManagedClustersResourceType     = "managedClusters"
 	capiImagePublisher              = "cncf-upstream"
 	capiOfferName                   = "capi"

--- a/test/e2e/gpu_operator.go
+++ b/test/e2e/gpu_operator.go
@@ -64,5 +64,5 @@ func InstallGPUOperator(ctx context.Context, inputGetter func() GPUOperatorSpecI
 func InstallNvidiaGPUOperatorChart(ctx context.Context, clusterProxy framework.ClusterProxy) {
 	By("Installing nvidia/gpu-operator via helm")
 	values := &helmVals.Options{}
-	InstallHelmChart(ctx, clusterProxy, nvidiaGPUOperatorNamespace, nvidiaHelmChartRepoURL, nvidiaGPUOperatorHelmChartName, nvidiaGPUOperatorHelmReleaseName, values)
+	InstallHelmChart(ctx, clusterProxy, nvidiaGPUOperatorNamespace, nvidiaHelmChartRepoURL, nvidiaGPUOperatorHelmChartName, nvidiaGPUOperatorHelmReleaseName, values, "")
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -936,7 +936,7 @@ func getPodLogs(ctx context.Context, clientset *kubernetes.Clientset, pod corev1
 }
 
 // InstallHelmChart takes a helm repo URL, a chart name, and release name, and installs a helm release onto the E2E workload cluster.
-func InstallHelmChart(ctx context.Context, clusterProxy framework.ClusterProxy, namespace, repoURL, chartName, releaseName string, options *helmVals.Options) {
+func InstallHelmChart(ctx context.Context, clusterProxy framework.ClusterProxy, namespace, repoURL, chartName, releaseName string, options *helmVals.Options, version string) {
 	kubeConfigPath := clusterProxy.GetKubeconfigPath()
 	settings := helmCli.New()
 	settings.KubeConfig = kubeConfigPath
@@ -968,6 +968,7 @@ func InstallHelmChart(ctx context.Context, clusterProxy framework.ClusterProxy, 
 		}
 		i.ReleaseName = releaseName
 		i.Namespace = namespace
+		i.Version = version
 		i.CreateNamespace = true
 		Eventually(func(g Gomega) {
 			cp, err := i.ChartPathOptions.LocateChart(chartName, helmCli.New())


### PR DESCRIPTION
This PR changes the surge behavior of the AzureMachinePool reconcile for scalesets. 

- MaxSurge will no longer be calculated or executed when only tagging information on the scaleset is in effect as no rolling update is required for tagging to the individual vms of a vmss