### PR TITLE
skip parent lookup since it is buggy and not needed by NR

### DIFF
--- a/exp/api/v1beta1/azuremachinepool_default.go
+++ b/exp/api/v1beta1/azuremachinepool_default.go
@@ -54,7 +54,6 @@ func (amp *AzureMachinePool) SetDefaults(client client.Client) error {
 		}
 	}
 
-
 	subscriptionID, err := infrav1.GetSubscriptionID(client, ownerAzureClusterName, ownerAzureClusterNamespace, 5)
 	if err != nil {
 		errs = append(errs, errors.Wrap(err, "failed to get subscription ID"))

--- a/exp/api/v1beta1/azuremachinepool_default.go
+++ b/exp/api/v1beta1/azuremachinepool_default.go
@@ -37,15 +37,23 @@ func (amp *AzureMachinePool) SetDefaults(client client.Client) error {
 		errs = append(errs, errors.Wrap(err, "failed to set default SSH public key"))
 	}
 
-	machinePool, err := azureutil.FindParentMachinePoolWithRetry(amp.Name, client, 5)
-	if err != nil {
-		errs = append(errs, errors.Wrap(err, "failed to find parent machine pool"))
+	// the lookups could fail due to mp not being ready. NR will always match cluster name and namespace to the amp namespace.
+	skipParentLookup := true
+	ownerAzureClusterName := amp.Namespace
+	ownerAzureClusterNamespace := amp.Namespace
+
+	if !skipParentLookup {
+		machinePool, err := azureutil.FindParentMachinePoolWithRetry(amp.Name, client, 5)
+		if err != nil {
+			errs = append(errs, errors.Wrap(err, "failed to find parent machine pool"))
+		}
+
+		ownerAzureClusterName, ownerAzureClusterNamespace, err = infrav1.GetOwnerAzureClusterNameAndNamespace(client, machinePool.Spec.ClusterName, machinePool.Namespace, 5)
+		if err != nil {
+			errs = append(errs, errors.Wrap(err, "failed to get owner cluster"))
+		}
 	}
 
-	ownerAzureClusterName, ownerAzureClusterNamespace, err := infrav1.GetOwnerAzureClusterNameAndNamespace(client, machinePool.Spec.ClusterName, machinePool.Namespace, 5)
-	if err != nil {
-		errs = append(errs, errors.Wrap(err, "failed to get owner cluster"))
-	}
 
 	subscriptionID, err := infrav1.GetSubscriptionID(client, ownerAzureClusterName, ownerAzureClusterNamespace, 5)
 	if err != nil {


### PR DESCRIPTION
 skips parent lookups of the machine pool and cluster since they are not needed for NR.  There is currently a bug with these lookups where they could return a nil pointer deref.  
